### PR TITLE
fix kubelet startup

### DIFF
--- a/k8s-worker/kubelet.service
+++ b/k8s-worker/kubelet.service
@@ -13,7 +13,6 @@ ExecStart=/usr/bin/kubelet \
   --cluster-dns=10.32.0.10  \
   --cluster-domain={{ clusterDomain }} \
   --hostname-override={{ hostname }} \
-  --experimental-bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig \
   --container-runtime=docker \
   --docker=unix:///var/run/docker.sock \
   --network-plugin=cni \


### PR DESCRIPTION
Fix kubelet startup problem. Kubelet with option(--experimental-bootstrap-kubeconfig) didn't read it config file and can't connect to kube-api.
FYI: I didn't check this changes on multi-master deployment.