### PR TITLE
refactor(states): sanitize some states

### DIFF
--- a/k8s-certs/init.sls
+++ b/k8s-certs/init.sls
@@ -6,32 +6,32 @@
 
 /var/lib/kubernetes/ca.pem:
   file.managed:
-    - source:  salt://k8s-certs/ca.pem
+    - source:  salt://{{ slspath }}/ca.pem
     - group: root
     - mode: 644
 
 /var/lib/kubernetes/ca-key.pem:
   file.managed:
-    - source:  salt://k8s-certs/ca-key.pem
+    - source:  salt://{{ slspath }}/ca-key.pem
     - group: root
     - mode: 600
 
 /var/lib/kubernetes/kubernetes-key.pem:
   file.managed:
-    - source:  salt://k8s-certs/kubernetes-key.pem
+    - source:  salt://{{ slspath }}/kubernetes-key.pem
     - group: root
     - mode: 600
 
 /var/lib/kubernetes/kubernetes.pem:
   file.managed:
-    - source:  salt://k8s-certs/kubernetes.pem
+    - source:  salt://{{ slspath }}/kubernetes.pem
     - group: root
     - mode: 644
 
 ## Token & Auth Policy
 /var/lib/kubernetes/token.csv:
   file.managed:
-    - source:  salt://k8s-certs/token.csv
+    - source:  salt://{{ slspath }}/token.csv
     - template: jinja
     - group: root
     - mode: 600

--- a/k8s-master/etcd/init.sls
+++ b/k8s-master/etcd/init.sls
@@ -34,7 +34,7 @@ etcd-latest-archive:
 {% if masterCount == 1 %}
 /etc/systemd/system/etcd.service:
   file.managed:
-    - source: salt://k8s-master/etcd/etcd.service
+    - source: salt://{{ slspath }}/etcd.service
     - user: root
     - template: jinja
     - group: root
@@ -42,7 +42,7 @@ etcd-latest-archive:
 {% elif masterCount == 3 %}
 /etc/systemd/system/etcd.service:
   file.managed:
-    - source: salt://k8s-master/etcd/etcd-ha.service
+    - source: salt://{{ slspath }}/etcd-ha.service
     - user: root
     - template: jinja
     - group: root

--- a/k8s-master/init.sls
+++ b/k8s-master/init.sls
@@ -2,7 +2,7 @@
 {%- set masterCount = pillar['kubernetes']['master']['count'] -%}
 
 include:
-  - k8s-master/etcd
+  - .etcd
 
 /usr/bin/kube-apiserver:
   file.managed:
@@ -34,7 +34,7 @@ include:
 {% if masterCount == 1 %}
 /etc/systemd/system/kube-apiserver.service:
     file.managed:
-    - source: salt://k8s-master/kube-apiserver.service
+    - source: salt://{{ slspath }}/kube-apiserver.service
     - user: root
     - template: jinja
     - group: root
@@ -42,7 +42,7 @@ include:
 {% elif masterCount == 3 %}
 /etc/systemd/system/kube-apiserver.service:
     file.managed:
-    - source: salt://k8s-master/kube-apiserver-ha.service
+    - source: salt://{{ slspath }}/kube-apiserver-ha.service
     - user: root
     - template: jinja
     - group: root
@@ -51,7 +51,7 @@ include:
 
 /etc/systemd/system/kube-controller-manager.service:
   file.managed:
-    - source: salt://k8s-master/kube-controller-manager.service
+    - source: salt://{{ slspath }}/kube-controller-manager.service
     - user: root
     - template: jinja
     - group: root
@@ -59,7 +59,7 @@ include:
 
 /etc/systemd/system/kube-scheduler.service:
   file.managed:
-    - source: salt://k8s-master/kube-scheduler.service
+    - source: salt://{{ slspath }}/kube-scheduler.service
     - user: root
     - template: jinja
     - group: root
@@ -67,7 +67,7 @@ include:
 
 /var/lib/kubernetes/encryption-config.yaml:    
     file.managed:
-    - source: salt://k8s-master/encryption-config.yaml
+    - source: salt://{{ slspath }}/encryption-config.yaml
     - user: root
     - template: jinja
     - group: root
@@ -78,7 +78,7 @@ include:
 
 /opt/calico.yaml:
     file.managed:
-    - source: salt://k8s-worker/cni/calico/calico.tmpl.yaml
+    - source: salt://{{ slspath.split('/')[0] }}/k8s-worker/cni/calico/calico.tmpl.yaml
     - user: root
     - template: jinja
     - group: root

--- a/k8s-worker/cni/calico/init.sls
+++ b/k8s-worker/cni/calico/init.sls
@@ -27,7 +27,7 @@
     - group: root
     - mode: 755
     - require:
-      - sls: k8s-worker/cni
+      - sls: {{ sls.split('.')[0] }}.k8s-worker.cni
 
 /opt/cni/bin/calico-ipam:
   file.managed:
@@ -36,25 +36,25 @@
     - group: root
     - mode: 755
     - require:
-      - sls: k8s-worker/cni
+      - sls: {{ sls.split('.')[0] }}.k8s-worker.cni
 
 /etc/calico/kube/kubeconfig:
     file.managed:
-    - source: salt://k8s-worker/cni/calico/kubeconfig
+    - source: salt://{{ slspath }}/kubeconfig
     - user: root
     - template: jinja
     - group: root
     - mode: 640
     - require:
-      - sls: k8s-worker/cni
+      - sls: {{ sls.split('.')[0] }}.k8s-worker.cni
 
 /etc/cni/net.d/10-calico.conf:
     file.managed:
-    - source: salt://k8s-worker/cni/calico/10-calico.conf
+    - source: salt://{{ slspath }}/10-calico.conf
     - user: root
     - template: jinja
     - group: root
     - mode: 644
     - require:
-      - sls: k8s-worker/cni
+      - sls: {{ sls.split('.')[0] }}.k8s-worker.cni
 

--- a/k8s-worker/cni/init.sls
+++ b/k8s-worker/cni/init.sls
@@ -22,4 +22,4 @@ cni-latest-archive:
     - if_missing: /opt/cni/bin/loopback
 
 include:
-  - k8s-worker/cni/{{ cniProvider }}
+  - .{{ cniProvider }}

--- a/k8s-worker/cri/docker/init.sls
+++ b/k8s-worker/cri/docker/init.sls
@@ -45,7 +45,7 @@ docker-latest-archive:
 
 /etc/systemd/system/docker.service:
     file.managed:
-    - source: salt://k8s-worker/cri/docker/docker.service
+    - source: salt://{{ slspath }}/docker.service
     - user: root
     - template: jinja
     - group: root

--- a/k8s-worker/init.sls
+++ b/k8s-worker/init.sls
@@ -4,8 +4,8 @@
 {%- set criProvider = pillar['kubernetes']['worker']['runtime']['provider'] -%}
 
 include:
-  - k8s-worker/cri/{{ criProvider }}
-  - k8s-worker/cni
+  - .cri/{{ criProvider }}
+  - .cni
 {% if os == "Debian" or os == "Ubuntu" %}
 glusterfs-client:
   pkg.latest
@@ -46,7 +46,7 @@ vm.max_map_count:
 
 /var/lib/kubelet/kubeconfig:
     file.managed:
-    - source: salt://k8s-worker/kubeconfig
+    - source: salt://{{ slspath }}/kubeconfig
     - user: root
     - template: jinja
     - group: root
@@ -54,7 +54,7 @@ vm.max_map_count:
 
 /etc/systemd/system/kubelet.service:
     file.managed:
-    - source: salt://k8s-worker/kubelet.service
+    - source: salt://{{ slspath }}/kubelet.service
     - user: root
     - template: jinja
     - group: root
@@ -62,7 +62,7 @@ vm.max_map_count:
 
 /etc/systemd/system/kube-proxy.service:
   file.managed:
-    - source: salt://k8s-worker/kube-proxy.service
+    - source: salt://{{ slspath }}/kube-proxy.service
     - user: root
     - template: jinja
     - group: root


### PR DESCRIPTION
this PR is mandatory to permit relocation of the salt sate to a salt master not located on a K8 master.


changes:
  - rebase root sls path from the real location in salt master

        from: <state file>/<state file>
        to:   {{ sls }}/<state file>

  - use relative path when possible

        from: <full path>/<state file>
        to:   .<state file>

  - do not use hard code path on salt master

        from: salt://k8s-worker/<path>/<file>
        to:   salt://{{ slspath }/<file>
