### PR TITLE
External salt master

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -1,0 +1,11 @@
+---
+{% if "k8s-master" in grains.get('role', []) or "k8s-worker" in grains.get('role', []) %}
+include:
+  - .k8s-certs
+{%   if "k8s-master" in grains.get('role', []) %}
+  - .k8s-master
+{%   endif %}
+{%   if "k8s-worker" in grains.get('role', []) %}
+  - .k8s-worker
+{%   endif %}
+{% endif %}

--- a/k8s-master/etcd/etcd-ha.service
+++ b/k8s-master/etcd/etcd-ha.service
@@ -8,6 +8,7 @@
 {%- set node01 =  pillar['kubernetes']['master']['cluster']['node01']['hostname'] -%} 
 {%- set node02 =  pillar['kubernetes']['master']['cluster']['node02']['hostname'] -%} 
 {%- set node03 =  pillar['kubernetes']['master']['cluster']['node03']['hostname'] -%} 
+{%- set clustername =  pillar['kubernetes']['master']['cluster']['name'] -%} 
 {% if hostname == node01 %}
 	{% set currentip = node01ip %}
 {% elif hostname == node02 %}
@@ -36,7 +37,7 @@ ExecStart=/usr/bin/etcd  \
 --advertise-client-urls https://{{ currentip }}:2379 \
 --listen-peer-urls https://{{ currentip }}:2380 \
 --initial-advertise-peer-urls https://{{ currentip }}:2380 \
---initial-cluster-token kubernete-cluster \
+--initial-cluster-token {{ clustername }} \
 --initial-cluster {{ node01 }}=https://{{ node01ip }}:2380,{{ node02 }}=https://{{ node02ip }}:2380,{{ node03 }}=https://{{ node03ip }}:2380 \
 --initial-cluster-state new \
 --peer-client-cert-auth \

--- a/k8s-master/etcd/etcd-ha.service
+++ b/k8s-master/etcd/etcd-ha.service
@@ -8,7 +8,7 @@
 {%- set node01 =  pillar['kubernetes']['master']['cluster']['node01']['hostname'] -%} 
 {%- set node02 =  pillar['kubernetes']['master']['cluster']['node02']['hostname'] -%} 
 {%- set node03 =  pillar['kubernetes']['master']['cluster']['node03']['hostname'] -%} 
-{%- set clustername =  pillar['kubernetes']['master']['cluster']['name'] -%} 
+{%- set clustername =  pillar['kubernetes']['master']['cluster']['name'] | default("kubernetes-cluster")-%}
 {% if hostname == node01 %}
 	{% set currentip = node01ip %}
 {% elif hostname == node02 %}

--- a/k8s-master/init.sls
+++ b/k8s-master/init.sls
@@ -1,5 +1,9 @@
 {%- set k8sVersion = pillar['kubernetes']['version'] -%}
 {%- set masterCount = pillar['kubernetes']['master']['count'] -%}
+{% set post_install_files = [ 
+  "coredns.yaml", "grafana.yaml", "heapster-rbac.yaml", "heapster.yaml",  
+  "influxdb.yaml", "kube-dns.yaml", "kubernetes-dashboard.yaml",  
+  "policy-controller.yaml", "rbac-calico.yaml", "rbac-tiller.yaml", "setup.sh"] %}
 
 include:
   - .etcd
@@ -85,6 +89,20 @@ include:
     - mode: 644
 {% endif %}
 
+{% for file in post_install_files %} 
+/opt/kubernetes/post_install/{{ file }}:
+  file.managed:
+  - source: salt://{{ slspath.split('/')[0] }}/post_install/{{ file }}
+  - makedirs: true
+  - template: jinja
+  - user: root
+  - group: root
+{% if file == "setup.sh" %}
+  - mode: 755
+{% else %}
+  - mode: 644
+{% endif %}
+{% endfor %}
 
 kube-apiserver:
   service.running:

--- a/k8s-master/init.sls
+++ b/k8s-master/init.sls
@@ -1,8 +1,8 @@
 {%- set k8sVersion = pillar['kubernetes']['version'] -%}
 {%- set masterCount = pillar['kubernetes']['master']['count'] -%}
-{% set post_install_files = [ 
-  "coredns.yaml", "grafana.yaml", "heapster-rbac.yaml", "heapster.yaml",  
-  "influxdb.yaml", "kube-dns.yaml", "kubernetes-dashboard.yaml",  
+{% set post_install_files = [
+  "coredns.yaml", "grafana.yaml", "heapster-rbac.yaml", "heapster.yaml",
+  "influxdb.yaml", "kube-dns.yaml", "kubernetes-dashboard.yaml",
   "policy-controller.yaml", "rbac-calico.yaml", "rbac-tiller.yaml", "setup.sh"] %}
 
 include:
@@ -69,7 +69,7 @@ include:
     - group: root
     - mode: 644
 
-/var/lib/kubernetes/encryption-config.yaml:    
+/var/lib/kubernetes/encryption-config.yaml:
     file.managed:
     - source: salt://{{ slspath }}/encryption-config.yaml
     - user: root
@@ -89,7 +89,7 @@ include:
     - mode: 644
 {% endif %}
 
-{% for file in post_install_files %} 
+{% for file in post_install_files %}
 /opt/kubernetes/post_install/{{ file }}:
   file.managed:
   - source: salt://{{ slspath.split('/')[0] }}/post_install/{{ file }}

--- a/k8s-worker/cni/calico/init.sls
+++ b/k8s-worker/cni/calico/init.sls
@@ -36,7 +36,7 @@
 
 /opt/cni/bin/calico-ipam:
   file.managed:
-    - source: 
+    - source:
 {%- if "v3.1" in calicoCniVersion %}
       - https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico-ipam
 {% else %}

--- a/k8s-worker/cni/calico/init.sls
+++ b/k8s-worker/cni/calico/init.sls
@@ -31,7 +31,9 @@
 
 /opt/cni/bin/calico-ipam:
   file.managed:
-    - source: https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico-ipam
+    - source: 
+      - https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico-ipam
+      - https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico-ipam-amd64
     - skip_verify: true
     - group: root
     - mode: 755

--- a/k8s-worker/cni/calico/init.sls
+++ b/k8s-worker/cni/calico/init.sls
@@ -22,7 +22,12 @@
 
 /opt/cni/bin/calico:
   file.managed:
-    - source: https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico
+    - source:
+{%- if "v3.1" in calicoCniVersion %}
+      - https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico
+{% else %}
+      - https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico-amd64
+{%- endif %}
     - skip_verify: true
     - group: root
     - mode: 755
@@ -32,8 +37,11 @@
 /opt/cni/bin/calico-ipam:
   file.managed:
     - source: 
+{%- if "v3.1" in calicoCniVersion %}
       - https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico-ipam
+{% else %}
       - https://github.com/projectcalico/cni-plugin/releases/download/{{ calicoCniVersion }}/calico-ipam-amd64
+{%- endif %}
     - skip_verify: true
     - group: root
     - mode: 755

--- a/k8s-worker/cni/init.sls
+++ b/k8s-worker/cni/init.sls
@@ -16,7 +16,9 @@
 cni-latest-archive:
   archive.extracted:
     - name: /opt/cni/bin
-    - source: https://github.com/containernetworking/plugins/releases/download/{{ cniVersion }}/cni-plugins-amd64-{{ cniVersion }}.tgz
+    - source: 
+      - https://github.com/containernetworking/plugins/releases/download/{{ cniVersion }}/cni-plugins-amd64-{{ cniVersion }}.tgz
+      - https://github.com/containernetworking/plugins/releases/download/{{ cniVersion }}/cni-plugins-linux-amd64-{{ cniVersion }}.tgz
     - skip_verify: true
     - archive_format: tar
     - if_missing: /opt/cni/bin/loopback

--- a/k8s-worker/cni/init.sls
+++ b/k8s-worker/cni/init.sls
@@ -17,8 +17,11 @@ cni-latest-archive:
   archive.extracted:
     - name: /opt/cni/bin
     - source: 
+{%- if "v0.7" in cniVersion %}
       - https://github.com/containernetworking/plugins/releases/download/{{ cniVersion }}/cni-plugins-amd64-{{ cniVersion }}.tgz
+{% else %}
       - https://github.com/containernetworking/plugins/releases/download/{{ cniVersion }}/cni-plugins-linux-amd64-{{ cniVersion }}.tgz
+{%- endif %}
     - skip_verify: true
     - archive_format: tar
     - if_missing: /opt/cni/bin/loopback

--- a/k8s-worker/cni/init.sls
+++ b/k8s-worker/cni/init.sls
@@ -16,7 +16,7 @@
 cni-latest-archive:
   archive.extracted:
     - name: /opt/cni/bin
-    - source: 
+    - source:
 {%- if "v0.7" in cniVersion %}
       - https://github.com/containernetworking/plugins/releases/download/{{ cniVersion }}/cni-plugins-amd64-{{ cniVersion }}.tgz
 {% else %}

--- a/k8s-worker/cri/docker/docker.service
+++ b/k8s-worker/cri/docker/docker.service
@@ -1,4 +1,4 @@
-{%- set data-dir = salt['pillar.get']('kubernetesi:worker:runtime:docker:data-dir') -%}
+{%- set data-dir = salt['pillar.get']('kubernetes:worker:runtime:docker:data-dir') -%}
 ### THIS FILE IS MANAGED BY SALTSTACK
 [Unit]
 

--- a/k8s-worker/cri/docker/docker.service
+++ b/k8s-worker/cri/docker/docker.service
@@ -1,4 +1,4 @@
-{%- set data-dir = salt['pillar.get']('kubernetes:worker:runtime:docker:data-dir') -%}
+{%- set datadir = salt['pillar.get']('kubernetes:worker:runtime:docker:data-dir') -%}
 ### THIS FILE IS MANAGED BY SALTSTACK
 [Unit]
 
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/dockerd \
   --ip-masq=false \
   --host=unix:///var/run/docker.sock \
   --log-level=error \
-  --data-root={{ data-dir }} \
+  --data-root={{ datadir }} \
   --storage-driver=overlay2
 Restart=on-failure
 RestartSec=5

--- a/k8s-worker/cri/docker/docker.service
+++ b/k8s-worker/cri/docker/docker.service
@@ -1,4 +1,4 @@
-{%- set data-dir = pillar['kubernetes']['worker']['runtime']['docker']['data-dir'] -%}
+{%- set data-dir = salt['pillar.get']('kubernetesi:worker:runtime:docker:data-dir') -%}
 ### THIS FILE IS MANAGED BY SALTSTACK
 [Unit]
 

--- a/k8s-worker/cri/docker/docker.service
+++ b/k8s-worker/cri/docker/docker.service
@@ -1,3 +1,4 @@
+{%- set data-dir = pillar['kubernetes']['worker']['runtime']['docker']['data-dir'] -%}
 ### THIS FILE IS MANAGED BY SALTSTACK
 [Unit]
 
@@ -12,7 +13,7 @@ ExecStart=/usr/bin/dockerd \
   --ip-masq=false \
   --host=unix:///var/run/docker.sock \
   --log-level=error \
-  --data-root=/dockerFS \
+  --data-root={{ data-dir }} \
   --storage-driver=overlay2
 Restart=on-failure
 RestartSec=5

--- a/k8s-worker/cri/docker/init.sls
+++ b/k8s-worker/cri/docker/init.sls
@@ -44,7 +44,7 @@ docker-latest-archive:
     - target: /opt/docker/docker-runc
 
 /etc/systemd/system/docker.service:
-    file.managed:
+  file.managed:
     - source: salt://{{ slspath }}/docker.service
     - user: root
     - template: jinja

--- a/pillar/cluster_config.sls
+++ b/pillar/cluster_config.sls
@@ -2,20 +2,20 @@ kubernetes:
   version: v1.11.2
   domain: cluster.local
   master:
-#    count: 1
-#    hostname: master.domain.tld
-#    ipaddr: 10.240.0.10
-    count: 3
-    cluster:
-      node01:
-        hostname: master01.domain.tld
-        ipaddr: 10.240.0.10
-      node02:
-        hostname: master02.domain.tld
-        ipaddr: 10.240.0.20
-      node03:
-        hostname: master03.domain.tld
-        ipaddr: 10.240.0.30
+    count: 1
+    hostname: ng110.paris.exalead.com
+    ipaddr: 10.81.242.228
+#    count: 3
+#    cluster:
+#      node01:
+#        hostname: master01.domain.tld
+#        ipaddr: 10.240.0.10
+#      node02:
+#        hostname: master02.domain.tld
+#        ipaddr: 10.240.0.20
+#      node03:
+#        hostname: master03.domain.tld
+#        ipaddr: 10.240.0.30
     encryption-key: 'w3RNESCMG+o3GCHTUcrQUUdq6CFV72q/Zik9LAO8uEc='
     etcd:
       version: v3.3.9

--- a/pillar/cluster_config.sls
+++ b/pillar/cluster_config.sls
@@ -2,20 +2,20 @@ kubernetes:
   version: v1.11.2
   domain: cluster.local
   master:
-    count: 1
-    hostname: ng110.paris.exalead.com
-    ipaddr: 10.81.242.228
-#    count: 3
-#    cluster:
-#      node01:
-#        hostname: master01.domain.tld
-#        ipaddr: 10.240.0.10
-#      node02:
-#        hostname: master02.domain.tld
-#        ipaddr: 10.240.0.20
-#      node03:
-#        hostname: master03.domain.tld
-#        ipaddr: 10.240.0.30
+#    count: 1
+#    hostname: master.domain.tld
+#    ipaddr: 10.240.0.10
+    count: 3
+    cluster:
+      node01:
+        hostname: master01.domain.tld
+        ipaddr: 10.240.0.10
+      node02:
+        hostname: master02.domain.tld
+        ipaddr: 10.240.0.20
+      node03:
+        hostname: master03.domain.tld
+        ipaddr: 10.240.0.30
     encryption-key: 'w3RNESCMG+o3GCHTUcrQUUdq6CFV72q/Zik9LAO8uEc='
     etcd:
       version: v3.3.9

--- a/pillar/cluster_config.sls
+++ b/pillar/cluster_config.sls
@@ -7,6 +7,7 @@ kubernetes:
 #    ipaddr: 10.240.0.10
     count: 3
     cluster:
+      name: kubernetes-cluster
       node01:
         hostname: master01.domain.tld
         ipaddr: 10.240.0.10

--- a/post_install/coredns.yaml
+++ b/post_install/coredns.yaml
@@ -49,7 +49,7 @@ data:
     .:53 {
         errors
         health
-        kubernetes CLUSTER_DOMAIN CLUSTER_DOMAIN {
+        kubernetes {{ salt['pillar.get']('kubernetes:domain') }} {{ salt['pillar.get']('kubernetes:domain') }} {
           pods insecure
           upstream
           fallthrough in-addr.arpa ip6.arpa

--- a/post_install/kube-dns.yaml
+++ b/post_install/kube-dns.yaml
@@ -70,7 +70,7 @@ spec:
             - name: PROMETHEUS_PORT
               value: "10055"
           args:
-            - --domain=CLUSTER_DOMAIN.
+            - --domain={{ salt['pillar.get']('kubernetes:domain') }}.
             - --dns-port=10053
             - --config-dir=/kube-dns-config
             - --v=2
@@ -124,7 +124,7 @@ spec:
             - -k
             - --cache-size=1000
             - --log-facility=-
-            - --server=/CLUSTER_DOMAIN/127.0.0.1#10053
+            - --server=/{{ salt['pillar.get']('kubernetes:domain') }}/127.0.0.1#10053
             - --server=/in-addr.arpa/127.0.0.1#10053
             - --server=/ip6.arpa/127.0.0.1#10053
           livenessProbe:
@@ -156,8 +156,8 @@ spec:
           args:
             - --v=2
             - --logtostderr
-            - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.CLUSTER_DOMAIN,5,A
-            - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.CLUSTER_DOMAIN,5,A
+            - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ salt['pillar.get']('kubernetes:domain') }},5,A
+            - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ salt['pillar.get']('kubernetes:domain') }},5,A
           livenessProbe:
             failureThreshold: 5
             httpGet:

--- a/post_install/kubernetes-dashboard.yaml
+++ b/post_install/kubernetes-dashboard.yaml
@@ -109,7 +109,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/post_install/kubernetes-dashboard.yaml
+++ b/post_install/kubernetes-dashboard.yaml
@@ -109,7 +109,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:{{ salt['pillar.get']('kubernetes:global:dashboard-version') }}
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/post_install/setup.sh
+++ b/post_install/setup.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-cd /srv/salt/post_install/
-
-HELM_VERSION=$(cat /srv/salt/pillar/cluster_config.sls |grep helm-version |sed  's/^.*: //g')
-CLUSTER_DOMAIN=$(cat /srv/salt/pillar/cluster_config.sls |grep domain |head -n 1 |sed  's/^.*: //g')
-
-sed -i -e "s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g" kube-dns.yaml
-sed -i -e "s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g" coredns.yaml
+HELM_VERSION=$(salt-call pillar.get --out=txt kubernetes:global:helm-version |cut -d ' ' -f 2)
 
 kubectl create -f rbac-calico.yaml
 kubectl create -f /opt/calico.yaml

--- a/post_install/setup.sh
+++ b/post_install/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HELM_VERSION=$(salt-call pillar.get --out=txt kubernetes:global:helm-version |cut -d ' ' -f 2)
+{% set HELM_VERSION = salt['pillar.get']('kubernetes:global:helm-version') -%}
 
 kubectl create -f rbac-calico.yaml
 kubectl create -f /opt/calico.yaml
@@ -14,10 +14,10 @@ kubectl create -f influxdb.yaml
 kubectl create -f grafana.yaml
 kubectl create -f heapster.yaml
 
-wget https://kubernetes-helm.storage.googleapis.com/helm-$HELM_VERSION-linux-amd64.tar.gz
-tar -zxvf helm-$HELM_VERSION-linux-amd64.tar.gz
+wget https://kubernetes-helm.storage.googleapis.com/helm-{{ HELM_VERSION }}-linux-amd64.tar.gz
+tar -zxvf helm-{{ HELM_VERSION }}-linux-amd64.tar.gz
 mv linux-amd64/helm /usr/local/bin/helm
-rm -r linux-amd64/ && rm -r helm-$HELM_VERSION-linux-amd64.tar.gz
+rm -r linux-amd64/ && rm -r helm-{{ HELM_VERSION }}-linux-amd64.tar.gz
 
 kubectl create serviceaccount tiller --namespace kube-system
 


### PR DESCRIPTION
this pull request solve #18  and #20

i introduce a condition for calico binaries and cni, because the target file is sufixed with the arch / OS of the binary

1. calicoCniVersion >v3.1 => calico-ipam -> calico-ipam-**amd64**
2. calicoCniVersion >v3.1 => calico-> calico-**amd64**
3. cniVersion > v0.7          =>  cni-plugins-amd64 -> cni-plugins-**linux**-amd64. 

I also add a new name for the cluster as a variable in case of more than 1 instance of kubernetes cluster and etcd setup.

the init.sls can replace the top.sls in case it s a folder in external salt master,.
the process generate a /opt/kubernetes/post_install/setup.sh with the yaml files, use it as usual

it works very well for me in various setup., i try it many times.


