### PR TITLE
x509 salt module/states instead of cfssl

### DIFF
--- a/k8s-certs/files.sls
+++ b/k8s-certs/files.sls
@@ -1,0 +1,37 @@
+/var/lib/kubernetes:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: 750
+
+/var/lib/kubernetes/ca.pem:
+  file.managed:
+    - source:  salt://{{ slspath }}/ca.pem
+    - group: root
+    - mode: 644
+
+/var/lib/kubernetes/ca-key.pem:
+  file.managed:
+    - source:  salt://{{ slspath }}/ca-key.pem
+    - group: root
+    - mode: 600
+
+/var/lib/kubernetes/kubernetes-key.pem:
+  file.managed:
+    - source:  salt://{{ slspath }}/kubernetes-key.pem
+    - group: root
+    - mode: 600
+
+/var/lib/kubernetes/kubernetes.pem:
+  file.managed:
+    - source:  salt://{{ slspath }}/kubernetes.pem
+    - group: root
+    - mode: 644
+
+## Token & Auth Policy
+/var/lib/kubernetes/token.csv:
+  file.managed:
+    - source:  salt://{{ slspath }}/token.csv
+    - template: jinja
+    - group: root
+    - mode: 600

--- a/k8s-certs/k8s_params.jinja
+++ b/k8s-certs/k8s_params.jinja
@@ -1,0 +1,17 @@
+{% set ca_certificates = salt['grains.filter_by']({
+      'Debian': {
+        'path': '/usr/local/share/ca-certificates',
+        'command' : 'update-ca-certificates --fresh'
+      },
+      'RedHat': {
+        'path': '/etc/pki/ca-trust/source/anchors',
+        'command' : 'update-ca-trust'
+      }
+    })
+%}
+{% set default_ca_host = salt["pillar.get"]("kubernetes:master:cluster:node01:hostname", salt["pillar.get"]("kubernetes:master:hostname")) %}
+{% set ca_host = salt["pillar.get"]("kubernetes:pki:host", default_ca_host) %}
+{% set pki_path = salt["pillar.get"]("kubernetes:pki:path","/opt/kubernetes/pki") %}
+{% set pki_cert = salt["pillar.get"]("kubernetes:pki:cert","kubernetes") %}
+{% set pki_ca = salt["pillar.get"]("kubernetes:pki:ca","kubernetes-ca") %}
+{% set wildcard = salt["pillar.get"]("kubernetes:pki:wildcard","*") %}

--- a/k8s-certs/signing_policies.conf
+++ b/k8s-certs/signing_policies.conf
@@ -1,0 +1,10 @@
+x509_signing_policies:
+  internal:
+    - minions: '{{ wildcard }}'
+    - signing_private_key: {{ pki_path }}/{{ pki_ca }}.key
+    - signing_cert: {{ pki_path }}/{{ pki_ca }}.crt
+    - basicConstraints: "critical CA:false"
+    - keyUsage: "critical keyEncipherment"
+    - subjectKeyIdentifier: hash
+    - authorityKeyIdentifier: keyid,issuer:always
+    - copypath: {{ pki_path }}/issued_certs

--- a/k8s-certs/x509-base.sls
+++ b/k8s-certs/x509-base.sls
@@ -1,0 +1,16 @@
+---
+{%- import slspath + "/k8s_params.jinja" as params with context %}
+/var/lib/kubernetes:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: 750
+
+k8s_salt_x509_module:
+  pkg.installed:
+    - name: m2crypto
+    - reload_modules: True
+  file.directory:
+    - name: {{ params.pki_path }}
+    - makedirs: True
+    - mode: 0700

--- a/k8s-certs/x509-ca.sls
+++ b/k8s-certs/x509-ca.sls
@@ -1,0 +1,50 @@
+---
+{%- import slspath + "/k8s_params.jinja" as params with context %}
+k8s_ca_certs_dir:
+  file.directory:
+    - name: "{{ params.pki_path }}/issued_certs"
+    - makedirs: True
+
+k8s_ca_signing_key:
+  x509.private_key_managed:
+    - name: "{{ params.pki_path }}/{{ params.pki_ca }}.key"
+    - bits: 4096
+    - require:
+      - file: k8s_ca_certs_dir
+
+k8s_ca_root_cert:
+  x509.certificate_managed:
+    - name: "{{ params.pki_path }}/{{ params.pki_ca }}.crt"
+    - signing_private_key: "{{ params.pki_path }}/{{ params.pki_ca }}.key"
+    - CN: {{grains['id']}}
+    - basicConstraints: "critical CA:true"
+    - keyUsage: "critical cRLSign, keyCertSign"
+    - subjectKeyIdentifier: hash
+    - authorityKeyIdentifier: keyid,issuer:always
+    - days_valid: 3650
+    - days_remaining: 0
+    - backup: True
+    - require:
+      - x509: k8s_ca_signing_key
+
+mine.send:
+  module.run:
+    - func: x509.get_pem_entries
+    - kwargs:
+        glob_path: "{{ params.pki_path }}/{{ params.pki_ca }}.*"
+    - onchanges:
+      - x509: k8s_ca_root_cert
+
+k8s_ca_signing_policies:
+  file.managed:
+    - name: /etc/salt/minion.d/signing_policies.conf
+    - source: salt://{{ slspath }}/signing_policies.conf
+    - template: jinja
+    - context:
+        pki_path: {{ params.pki_path }}
+        pki_ca: {{ params.pki_ca }}
+        wildcard: '{{ params.wildcard }}'
+  service.running:
+    - name: salt-minion
+    - watch:
+      - file: k8s_ca_signing_policies

--- a/k8s-certs/x509-files.sls
+++ b/k8s-certs/x509-files.sls
@@ -1,0 +1,27 @@
+---
+{%- import slspath + "/k8s_params.jinja" as params with context %}
+/var/lib/kubernetes/ca.pem:
+  file.managed:
+    - source: {{ params.ca_certificates.path }}/{{ params.pki_ca }}.crt
+    - group: root
+    - mode: 644
+
+/var/lib/kubernetes/kubernetes-key.pem:
+  file.managed:
+    - source: {{ params.pki_path }}/{{ params.pki_cert }}.key
+    - group: root
+    - mode: 600
+
+/var/lib/kubernetes/kubernetes.pem:
+  file.managed:
+    - source: {{ params.pki_path }}/{{ params.pki_cert }}.crt
+    - group: root
+    - mode: 644
+
+## Token & Auth Policy
+/var/lib/kubernetes/token.csv:
+  file.managed:
+    - source:  salt://{{ slspath }}/token.csv
+    - template: jinja
+    - group: root
+    - mode: 600

--- a/k8s-certs/x509-req.sls
+++ b/k8s-certs/x509-req.sls
@@ -1,0 +1,57 @@
+---
+{%- import slspath + "/k8s_params.jinja" as params with context %}
+k8s_internal_ca:
+{%- if params.ca_host == salt["grains.get"]("fqdn") %}
+  file.managed:
+    - name: "{{ params.ca_certificates.path }}/{{ params.pki_ca }}.crt"
+    - source: "{{ params.pki_path }}/{{ params.pki_ca }}.crt"
+    - makedirs: True
+{% else %}
+  file.directory:
+    - name: "{{ params.ca_certificates.path }}"
+  x509.pem_managed:
+    - name: "{{ params.ca_certificates.path }}/{{ params.pki_ca }}.crt"
+    - text: {{ salt["mine.get"](params.ca_host, "x509.get_pem_entries") | traverse(params.ca_host + ":" + params.pki_path + "/" + params.pki_ca + ".crt") | replace("\n", "") }}
+{%- endif %}
+  cmd.run:
+    - name: {{ params.ca_certificates.command }}
+    - onchanges:
+{%- if params.ca_host == salt["grains.get"]("fqdn") %}
+      - file: k8s_internal_ca
+{% else %}
+      - x509: k8s_internal_ca
+{%- endif %}
+
+k8s_internal_ca_key:
+{%- if params.ca_host == salt["grains.get"]("fqdn") %}
+  file.managed:
+    - name: "/var/lib/kubernetes/ca-key.pem"
+    - source: "{{ params.pki_path }}/{{ params.pki_ca }}.key"
+{% else %}
+  x509.pem_managed:
+    - name: "/var/lib/kubernetes/ca-key.pem"
+    - text: {{ salt["mine.get"](params.ca_host, "x509.get_pem_entries") | traverse(params.ca_host + ":" + params.pki_path + "/" + params.pki_ca + ".key") | replace("\n", "") }}
+    - makedirs: True
+{%- endif %}
+
+k8s_key:
+  x509.private_key_managed:
+    - name: "{{ params.pki_path }}/{{ params.pki_cert }}.key"
+    - bits: 4096
+ 
+{%- set ip_list = [] %}
+{%- do ip_list.append("IP:" + ((salt["pillar.get"]("kubernetes:global:clusterIP-range","10.32.0.0/16").split("/")[0] + "/30") | ipaddr | network_hosts)[0]) %}
+{%- for ip in salt['grains.get']('ipv4') %}
+{%- do ip_list.append("IP:" + ip) %}
+{%- endfor %}
+
+k8s_cert:
+  x509.certificate_managed:
+    - name: "{{ params.pki_path }}/{{ params.pki_cert }}.crt"
+    - ca_server: {{ params.ca_host }}
+    - signing_policy: internal
+    - public_key: "{{ params.pki_path }}/{{ params.pki_cert }}.key"
+    - CN: {{ salt['grains.get']('fqdn') }}
+    - subjectAltName: 'DNS:{{ salt["grains.get"]("fqdn") }}, {{ ip_list | join(", ") }}'
+    - days_valid: 30
+    - days_remaining: 10

--- a/pillar/cluster_config.sls
+++ b/pillar/cluster_config.sls
@@ -1,6 +1,10 @@
 kubernetes:
   version: v1.11.2
   domain: cluster.local
+  pki:
+    enable: true
+    host: master01.domain.tld
+    wildcard: '*.domain.tld'
   master:
 #    count: 1
 #    hostname: master.domain.tld


### PR DESCRIPTION
this is a PR for #1 

it works well, but i think it can be useful to add some new parameters for signing policy in case of more than one  CA and in case of many kubernetes clusters.

