### PR TITLE
fix(x509): some fixes on the X509 salt internal pki

### DIFF
--- a/README_PKI.md
+++ b/README_PKI.md
@@ -69,7 +69,22 @@ ln -s /srv/salt/pillar /srv/pillar
 After that, edit the `pillar/cluster_config.sls` to configure your future Kubernetes cluster :
 
 ```yaml
+kubernetes:
+  pki:
+    enable: true
+    host: <fqdn>
+    wildcard: '*'
 ```
+and you need to verify your salt master grant peers to use x509.sign_remote_certificate update the file `/etc/salt/master.d/client_acl.conf`
+
+```yaml
+peer:
+  .*:
+    - x509.sign_remote_certificate
+```
+
+and then restart the salt master
+
 ##### Don't forget to change hostnames & tokens  using command like `pwgen 64` !
 
 If you want to enable IPv6 on pod's side, you need to change `kubernetes.worker.networking.calico.ipv6.enable` to `true`.

--- a/README_PKI.md
+++ b/README_PKI.md
@@ -175,7 +175,21 @@ kube-system   monitoring-influxdb-85cb4985d4-rd776    1/1       Running   0     
 
 ## Good to know with internal salt PKI
 
-you need to start the pki at first, so run the highstate on this node at first (default is kubernetes:cluster:node01)
+you need to start the pki at first, so you must add acl peer settings file  `/etc/salt/master.d/client_acl.conf` to the salt master 
+
+```yaml
+## use .* or another regexp rule
+peer:
+  .*:
+      - x509.sign_remote_certificate
+```
+
+and then add the `/etc/salt/minion.d/signing_policies.conf` on node01 (k8s master)
+```bash
+salt 'node01*' k8s-certs
+```
+
+if `k8s-certs` is not a top folder, you need to add the relative path like `git.kubernetes.Kubernetes-Saltstack.k8s-certs`
 
 If you want add a node on your Kubernetes cluster, just add the role into the grains of the server, and then run the command on the new node
 

--- a/k8s-certs/init.sls
+++ b/k8s-certs/init.sls
@@ -5,10 +5,10 @@ include:
 {%-   if ca_host == salt["grains.get"]("fqdn") %}
   - .x509-ca
 {%-   endif %}
-{%-   if salt["mine.get"](ca_host, "x509.get_pem_entries")  or ca_host == salt["grains.get"]("fqdn") %}
+{%-   if ('/etc/salt/minion.d/signing_policies.conf' | is_text_file) and (salt["mine.get"](ca_host, "x509.get_pem_entries")  or ca_host == salt["grains.get"]("fqdn")) %}
   - .x509-req
-  - .x509-files 
+  - .x509-files
 {%-   endif %}
 {%  else %}
-  - .files 
+  - .files
 {%- endif %}

--- a/k8s-certs/k8s_params.jinja
+++ b/k8s-certs/k8s_params.jinja
@@ -15,3 +15,13 @@
 {% set pki_cert = salt["pillar.get"]("kubernetes:pki:cert","kubernetes") %}
 {% set pki_ca = salt["pillar.get"]("kubernetes:pki:ca","kubernetes-ca") %}
 {% set wildcard = salt["pillar.get"]("kubernetes:pki:wildcard","*") %}
+
+# Select the m2crypt python pkg, depend of the osmalily and os version
+{% set m2crypto = salt['grains.filter_by']({
+    'Debian': 'python3-m2crypto',
+    'RedHat': salt['grains.filter_by']({
+       '8': 'python3-m2crypto',
+       '7': 'm2crypto'
+     }, grain='osmajorrelease', default='8'),
+  })
+%}

--- a/k8s-certs/x509-base.sls
+++ b/k8s-certs/x509-base.sls
@@ -8,7 +8,7 @@
 
 k8s_salt_x509_module:
   pkg.installed:
-    - name: m2crypto
+    - name: {{ params.m2crypto }}
     - reload_modules: True
   file.directory:
     - name: {{ params.pki_path }}

--- a/k8s-certs/x509-req.sls
+++ b/k8s-certs/x509-req.sls
@@ -1,5 +1,6 @@
 ---
 {%- import slspath + "/k8s_params.jinja" as params with context %}
+{%- set ten_days = salt['x509.will_expire'](params.pki_path + '/' + params.pki_cert +'.crt',10) %}
 k8s_internal_ca:
 {%- if params.ca_host == salt["grains.get"]("fqdn") %}
   file.managed:
@@ -45,6 +46,7 @@ k8s_key:
 {%- do ip_list.append("IP:" + ip) %}
 {%- endfor %}
 
+{%- if ten_days.will_expire | default(True) %}
 k8s_cert:
   x509.certificate_managed:
     - name: "{{ params.pki_path }}/{{ params.pki_cert }}.crt"
@@ -55,3 +57,4 @@ k8s_cert:
     - subjectAltName: 'DNS:{{ salt["grains.get"]("fqdn") }}, {{ ip_list | join(", ") }}'
     - days_valid: 365
     - days_remaining: 10
+{%- endif %}

--- a/k8s-worker/cni/calico/init.sls
+++ b/k8s-worker/cni/calico/init.sls
@@ -3,7 +3,7 @@
 
 # set k8s-worker.cni if k8s-worker is at the same level of top.sls
 # set <path>.k8s-worker.cni if k8s-worker is in a sub folder
-{% set require_cni = "k8s-worker.cni" %}
+{% set require_cni = "cni-latest-archive" %}
 
 /usr/bin/calicoctl:
   file.managed:
@@ -36,7 +36,7 @@
     - group: root
     - mode: 755
     - require:
-      - sls: {{ require_cni }}
+      - id: {{ require_cni }}
 
 /opt/cni/bin/calico-ipam:
   file.managed:
@@ -50,7 +50,7 @@
     - group: root
     - mode: 755
     - require:
-      - sls: {{ require_cni }}
+      - id: {{ require_cni }}
 
 /etc/calico/kube/kubeconfig:
     file.managed:
@@ -60,8 +60,7 @@
     - group: root
     - mode: 640
     - require:
-      - sls: {{ require_cni }}
-
+      - id: {{ require_cni }}
 
 /etc/calico/calicoctl.cfg:
     file.managed:
@@ -71,7 +70,7 @@
     - group: root
     - mode: 640
     - require:
-      - sls: {{ require_cni }}
+      - id: {{ require_cni }}
 
 /etc/cni/net.d/10-calico.conf:
     file.managed:
@@ -81,4 +80,4 @@
     - group: root
     - mode: 644
     - require:
-      - sls: {{ require_cni }}
+      - id: {{ require_cni }}


### PR DESCRIPTION
The fixes:
  - race condition: ensure the salt pki is ready
  - bug: the pyth3 version of salt minion have some issue to
    evaluate the reamining time of the certificate
  - pkg: use python-m2crypto on RedHat 8 os family distros